### PR TITLE
Update for compatibility with slate@0.22.x

### DIFF
--- a/lib/createCell.js
+++ b/lib/createCell.js
@@ -7,7 +7,7 @@ const Slate = require('slate');
  * @return {Slate.Node}
  */
 function createCell(opts, text) {
-    text = text || '';
+    text = text || ' ';
     const { typeCell, typeContent } = opts;
 
     return Slate.Block.create({

--- a/lib/defaultRenderers.js
+++ b/lib/defaultRenderers.js
@@ -1,4 +1,4 @@
-import React from 'react';
+const React = require('react');
 
 /**
  * split rows into thead contens and body contents,
@@ -27,7 +27,7 @@ const makeRenderers = (opts = {}) => ({
 
         return (
             <table>
-                {header && 
+                {header &&
                     <thead {...props.attributes}>
                         {header}
                     </thead>

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,6 @@ const KEY_BACKSPACE = 'backspace';
 const KEY_DOWN      = 'down';
 const KEY_UP        = 'up';
 
-
 /**
  * @param {String} opts.typeTable The type of table blocks
  * @param {String} opts.typeRow The type of row blocks
@@ -41,28 +40,29 @@ function EditTable(opts) {
         const { startBlock } = state;
         if (!startBlock) return false;
 
-        return TablePosition.isInCell(state, startBlock, opts) ;
+        return TablePosition.isInCell(state, startBlock, opts);
     }
 
     /**
-     * Bind a transform
+     * Bind a change
      */
     function bindTransform(fn) {
-        return function(transform, ...args) {
-            const { state } = transform;
+        return function(change, ...args) {
+            const { state } = change;
 
             if (!isSelectionInTable(state)) {
-                return transform;
+                return change;
             }
 
-            return fn(...[opts, transform].concat(args));
+            return fn(...[opts, change].concat(args));
         };
     }
 
     /**
      * User is pressing a key in the editor
      */
-    function onKeyDown(e, data, state) {
+    function onKeyDown(e, data, change) {
+        const { state } = change;
         // Only handle events in cells
         if (!isSelectionInTable(state)) {
             return;
@@ -70,7 +70,7 @@ function EditTable(opts) {
 
         // Build arguments list
         const args = [
-            e, data, state,
+            e, data, change,
             opts
         ];
 

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -49,12 +49,12 @@ function AlwaysBlocksWithinCell(opts) {
         },
 
         // If any, wrap in blocks
-        normalize(transform, node, toWrap) {
-            transform = toWrap.reduce((tr, unwrapped) =>
+        normalize(change, node, toWrap) {
+            change = toWrap.reduce((tr, unwrapped) =>
                 tr.wrapBlockByKey(unwrapped.key, opts.typeContent, { normalize: false })
-            , transform);
+            , change);
 
-            return transform;
+            return change;
         }
     };
 }
@@ -88,12 +88,12 @@ function cellsWithinTable(opts) {
         },
 
         // If any, wrap all cells in a row block
-        normalize(transform, node, { cells }) {
-            transform = cells.reduce((tr, cell) => {
+        normalize(change, node, { cells }) {
+            change = cells.reduce((tr, cell) => {
                 return tr.wrapBlockByKey(cell.key, opts.typeRow, { normalize: false });
-            }, transform);
+            }, change);
 
-            return transform;
+            return change;
         }
     };
 }
@@ -127,14 +127,14 @@ function rowsWithinTable(opts) {
         },
 
         // If any, wrap all cells in a row block
-        normalize(transform, node, { rows }) {
-            transform = rows.reduce((tr, row) => {
+        normalize(change, node, { rows }) {
+            change = rows.reduce((tr, row) => {
                 return tr.wrapBlockByKey(row.key, {
                     type: opts.typeTable,
                 }, { normalize: false });
-            }, transform);
+            }, change);
 
-            return transform;
+            return change;
         }
     };
 }
@@ -175,18 +175,18 @@ function tablesContainOnlyRows(opts) {
          * Replaces the node's children
          * @param {List<Nodes>} value.nodes
          */
-        normalize(transform, node, {invalids = [], add = []}) {
+        normalize(change, node, {invalids = [], add = []}) {
             // Remove invalids
-            transform = invalids.reduce((t, child) => {
+            change = invalids.reduce((t, child) => {
                 return t.removeNodeByKey(child.key, { normalize: false });
-            }, transform);
+            }, change);
 
             // Add valids
-            transform = add.reduce((t, child) => {
+            change = add.reduce((t, child) => {
                 return t.insertNodeByKey(node.key, 0, child);
-            }, transform);
+            }, change);
 
-            return transform;
+            return change;
         }
     };
 }
@@ -227,18 +227,18 @@ function rowsContainOnlyCells(opts) {
          * Replaces the node's children
          * @param {List<Nodes>} value.nodes
          */
-        normalize(transform, node, {invalids = [], add = []}) {
+        normalize(change, node, {invalids = [], add = []}) {
             // Remove invalids
-            transform = invalids.reduce((t, child) => {
+            change = invalids.reduce((t, child) => {
                 return t.removeNodeByKey(child.key, { normalize: false });
-            }, transform);
+            }, change);
 
             // Add valids
-            transform = add.reduce((t, child) => {
+            change = add.reduce((t, child) => {
                 return t.insertNodeByKey(node.key, 0, child);
-            }, transform);
+            }, change);
 
-            return transform;
+            return change;
         }
     };
 }
@@ -296,7 +296,7 @@ function rowsContainRequiredColumns(opts) {
          * Updates by key every given nodes
          * @param {List<Nodes>} value.toUpdate
          */
-        normalize(transform, node, rows) {
+        normalize(change, node, rows) {
             return rows.reduce((tr, { row, invalids, add }) => {
                 tr = invalids.reduce((t, child) => {
                     return t.removeNodeByKey(child.key, { normalize: false });
@@ -308,7 +308,7 @@ function rowsContainRequiredColumns(opts) {
                 }, tr);
 
                 return tr;
-            }, transform);
+            }, change);
         }
     };
 }

--- a/lib/onTab.js
+++ b/lib/onTab.js
@@ -4,41 +4,41 @@ const insertRow = require('./transforms/insertRow');
 
 /**
  * Select all text of current block.
- * @param {Slate.Transform} transform
- * @return {Slate.Transform}
+ * @param {Slate.Change} change
+ * @return {Slate.Change}
  */
-function selectAllText(transform) {
-    const { state } = transform;
+function selectAllText(change) {
+    const { state } = change;
     const { startBlock } = state;
 
-    return transform
+    return change
         .moveOffsetsTo(0)
-        .extend(startBlock.length);
+        .extend(startBlock.textlength);
 }
 
 /**
  * Pressing "Tab" moves the cursor to the next cell
  * and select the whole text
  */
-function onTab(event, data, state, opts) {
+function onTab(event, data, change, opts) {
+    const { state } = change;
     event.preventDefault();
     const direction = (data.isShift ? -1 : +1);
-    let transform = state.transform();
 
     // Create new row if needed
     const { startBlock } = state;
     const pos = TablePosition.create(state, startBlock, opts);
     if (pos.isFirstCell() && direction === -1) {
-        transform = insertRow(opts, transform, 0);
+        change = insertRow(opts, change, 0);
     } else if (pos.isLastCell() && direction === 1) {
-        transform = insertRow(opts, transform);
+        change = insertRow(opts, change);
     }
 
     // Move
-    transform = moveSelectionBy(opts, transform, direction, 0);
+    change = moveSelectionBy(opts, change, direction, 0);
 
     // Select all cell.
-    return selectAllText(transform).apply();
+    return selectAllText(change);
 }
 
 module.exports = onTab;

--- a/lib/onUpDown.js
+++ b/lib/onUpDown.js
@@ -1,8 +1,8 @@
 const TablePosition = require('./TablePosition');
 const moveSelectionBy = require('./transforms/moveSelectionBy');
 
-function onUpDown(event, data, state, opts) {
-
+function onUpDown(event, data, change, opts) {
+    const { state } = change;
     const direction = data.key === 'up' ? -1 : +1;
     const { startBlock } = state;
     const pos = TablePosition.create(state, startBlock, opts);
@@ -10,18 +10,17 @@ function onUpDown(event, data, state, opts) {
     if ((pos.isFirstRow() && direction === -1)
         || (pos.isLastRow() && direction === +1)) {
         // Let the default behavior move out of the table
-        return state;
+        return change;
 
     } else {
         event.preventDefault();
 
-        let transform = state.transform();
-        transform = moveSelectionBy(
-            opts, transform,
+        change = moveSelectionBy(
+            opts, change,
             0, data.key === 'up' ? -1 : +1
         );
 
-        return transform.apply();
+        return change;
     }
 }
 

--- a/lib/transforms/insertColumn.js
+++ b/lib/transforms/insertColumn.js
@@ -7,12 +7,12 @@ const createCell = require('../createCell');
  * Insert a new column in current table
  *
  * @param {Object} opts
- * @param {Slate.Transform} transform
+ * @param {Slate.Change} change
  * @param {Number} at
- * @return {Slate.Transform}
+ * @return {Slate.Change}
  */
-function insertColumn(opts, transform, at) {
-    const { state } = transform;
+function insertColumn(opts, change, at) {
+    const { state } = change;
     const { startBlock } = state;
 
     const pos = TablePosition.create(state, startBlock, opts);
@@ -25,11 +25,11 @@ function insertColumn(opts, transform, at) {
     // Insert the new cell
     table.nodes.forEach((row) => {
         const newCell = createCell(opts);
-        transform = transform.insertNodeByKey(row.key, at, newCell);
+        change = change.insertNodeByKey(row.key, at, newCell);
     });
 
     // Update the selection (not doing can break the undo)
-    return moveSelection(opts, transform, pos.getColumnIndex() + 1, pos.getRowIndex());
+    return moveSelection(opts, change, pos.getColumnIndex() + 1, pos.getRowIndex());
 }
 
 module.exports = insertColumn;

--- a/lib/transforms/insertRow.js
+++ b/lib/transforms/insertRow.js
@@ -5,13 +5,13 @@ const TablePosition = require('../TablePosition');
  * Insert a new row in current table
  *
  * @param {Object} opts
- * @param {Slate.Transform} transform
+ * @param {Slate.Change} change
  * @param {Number} at
  * @param {Function} textGetter
- * @return {Slate.Transform}
+ * @return {Slate.Change}
  */
-function insertRow(opts, transform, at, textGetter) {
-    const { state } = transform;
+function insertRow(opts, change, at, textGetter) {
+    const { state } = change;
     const { startBlock } = state;
 
     const pos = TablePosition.create(state, startBlock, opts);
@@ -25,7 +25,7 @@ function insertRow(opts, transform, at, textGetter) {
         at = pos.getRowIndex() + 1;
     }
 
-    return transform
+    return change
 
         .insertNodeByKey(table.key, at, newRow)
 

--- a/lib/transforms/insertTable.js
+++ b/lib/transforms/insertTable.js
@@ -4,13 +4,13 @@ const createTable = require('../createTable');
  * Insert a new table
  *
  * @param {Object} opts
- * @param {Slate.Transform} transform
+ * @param {Slate.Change} change
  * @param {Number} columns
  * @param {Number} rows
- * @return {Slate.Transform}
+ * @return {Slate.Change}
  */
-function insertTable(opts, transform, columns = 2, rows = 2) {
-    const { state } = transform;
+function insertTable(opts, change, columns = 2, rows = 2) {
+    const { state } = change;
 
     if (!state.selection.startKey) return false;
 
@@ -18,7 +18,7 @@ function insertTable(opts, transform, columns = 2, rows = 2) {
     const fillWithEmptyText = (x, y) => '';
     const table = createTable(opts, columns, rows, fillWithEmptyText);
 
-    const done = transform
+    const done = change
         .insertBlock(table);
     return done;
 }

--- a/lib/transforms/moveSelection.js
+++ b/lib/transforms/moveSelection.js
@@ -4,13 +4,13 @@ const TablePosition = require('../TablePosition');
  * Move selection to {x,y}
  *
  * @param {Object} opts
- * @param {Slate.Transform} transform
+ * @param {Slate.Change} change
  * @param {Number} x
  * @param {Number} y
- * @return {Slate.Transform}
+ * @return {Slate.Change}
  */
-function moveSelection(opts, transform, x, y) {
-    const { state } = transform;
+function moveSelection(opts, change, x, y) {
+    const { state } = change;
     let { startBlock, startOffset } = state;
 
     if (!TablePosition.isInCell(state, startBlock, opts)) {
@@ -28,7 +28,9 @@ function moveSelection(opts, transform, x, y) {
         startOffset = cell.length;
     }
 
-    return transform
+    console.warn(cell);
+
+    return change
         .collapseToEndOf(cell)
         .moveOffsetsTo(startOffset);
 }

--- a/lib/transforms/moveSelectionBy.js
+++ b/lib/transforms/moveSelectionBy.js
@@ -5,13 +5,13 @@ const moveSelection = require('./moveSelection');
  * Move selection by a {x,y} relative movement
  *
  * @param {Object} opts
- * @param {Slate.Transform} transform
+ * @param {Slate.Change} change
  * @param {Number} x Move horizontally by x
  * @param {Number} y Move vertically by y
- * @return {Slate.Transform}
+ * @return {Slate.Change}
  */
-function moveSelectionBy(opts, transform, x, y) {
-    const { state } = transform;
+function moveSelectionBy(opts, change, x, y) {
+    const { state } = change;
     const { startBlock } = state;
 
     if (!TablePosition.isInCell(state, startBlock, opts)) {
@@ -28,10 +28,10 @@ function moveSelectionBy(opts, transform, x, y) {
 
     if (absX === -1) {
         // Out of table
-        return transform;
+        return change;
     }
 
-    return moveSelection(opts, transform, absX, absY);
+    return moveSelection(opts, change, absX, absY);
 }
 
 /**

--- a/lib/transforms/removeColumn.js
+++ b/lib/transforms/removeColumn.js
@@ -6,12 +6,12 @@ const TablePosition = require('../TablePosition');
  * Delete current column in a table
  *
  * @param {Object} opts
- * @param {Slate.Transform} transform
+ * @param {Slate.Change} change
  * @param {Number} at
- * @return {Slate.Transform}
+ * @return {Slate.Change}
  */
-function removeColumn(opts, transform, at) {
-    const { state } = transform;
+function removeColumn(opts, change, at) {
+    const { state } = change;
     const { startBlock } = state;
 
     const pos = TablePosition.create(state, startBlock, opts);
@@ -27,7 +27,7 @@ function removeColumn(opts, transform, at) {
     if (pos.getWidth() > 1) {
         rows.forEach((row) => {
             const cell = row.nodes.get(at);
-            transform.removeNodeByKey(cell.key);
+            change.removeNodeByKey(cell.key);
         });
     }
     // If last column, clear text in cells instead
@@ -36,7 +36,7 @@ function removeColumn(opts, transform, at) {
             row.nodes.forEach((cell) => {
                 // remove existing children
                 cell.nodes.forEach((node) => {
-                    transform.removeNodeByKey(node.key);
+                    change.removeNodeByKey(node.key);
                 });
                 // add the empty child content node
                 const emptyChild = Slate.Block.create({
@@ -48,13 +48,13 @@ function removeColumn(opts, transform, at) {
                         }, { terse: true })
                     ]
                 });
-                transform.insertNodeByKey(cell.key, 0, emptyChild);
+                change.insertNodeByKey(cell.key, 0, emptyChild);
             });
         });
     }
 
     // Replace the table
-    return transform;
+    return change;
 }
 
 module.exports = removeColumn;

--- a/lib/transforms/removeRow.js
+++ b/lib/transforms/removeRow.js
@@ -5,12 +5,12 @@ const TablePosition = require('../TablePosition');
  * Remove current row in a table. Clear it if last remaining row
  *
  * @param {Object} opts
- * @param {Slate.Transform} transform
+ * @param {Slate.Change} change
  * @param {Number} at
- * @return {Slate.Transform}
+ * @return {Slate.Change}
  */
-function removeRow(opts, transform, at) {
-    const { state } = transform;
+function removeRow(opts, change, at) {
+    const { state } = change;
     const { startBlock } = state;
 
     const pos = TablePosition.create(state, startBlock, opts);
@@ -23,14 +23,14 @@ function removeRow(opts, transform, at) {
     const row = table.nodes.get(at);
     // Update table by removing the row
     if (pos.getHeight() > 1) {
-        transform.removeNodeByKey(row.key);
+        change.removeNodeByKey(row.key);
     }
     // If last remaining row, clear it instead
     else {
         row.nodes.forEach((cell) => {
             // remove existing children
             cell.nodes.forEach((node) => {
-                transform.removeNodeByKey(node.key);
+                change.removeNodeByKey(node.key);
             });
             // add the empty child content node
             const emptyChild = Slate.Block.create({
@@ -42,11 +42,11 @@ function removeRow(opts, transform, at) {
                     }, { terse: true })
                 ]
             });
-            transform.insertNodeByKey(cell.key, 0, emptyChild);
+            change.insertNodeByKey(cell.key, 0, emptyChild);
         });
     }
 
-    return transform;
+    return change;
 }
 
 module.exports = removeRow;

--- a/lib/transforms/removeTable.js
+++ b/lib/transforms/removeTable.js
@@ -4,18 +4,18 @@ const TablePosition = require('../TablePosition');
  * Delete the whole table
  *
  * @param {Object} opts
- * @param {Slate.Transform} transform
+ * @param {Slate.Change} change
  * @param {Number} at
- * @return {Slate.Transform}
+ * @return {Slate.Change}
  */
-function removeTable(opts, transform, at) {
-    const { state } = transform;
+function removeTable(opts, change, at) {
+    const { state } = change;
     const { startBlock } = state;
 
     const pos = TablePosition.create(state, startBlock, opts);
     const { table } = pos;
 
-    return transform
+    return change
         .deselect()
         .removeNodeByKey(table.key);
 }

--- a/lib/transforms/toggleHeaders.js
+++ b/lib/transforms/toggleHeaders.js
@@ -4,25 +4,25 @@ const TablePosition = require('../TablePosition');
  * Toggles table headers on / off
  *
  * @param {Object} opts
- * @param {Slate.Transform} transform
- * @return {Slate.Transform}
+ * @param {Slate.Change} change
+ * @return {Slate.Change}
  */
-function toggleHeaders(opts, transform) {
-    const { state } = transform;
+function toggleHeaders(opts, change) {
+    const { state } = change;
     const { startBlock } = state;
 
     const pos = TablePosition.create(state, startBlock, opts);
     const { table } = pos;
-    
+
     const currentSetting = !!table.get('data').get('headless');
 
-    transform.setNodeByKey(table.key, {
+    change.setNodeByKey(table.key, {
         data: {
             headless: !currentSetting
         }
     });
 
-    return transform;
+    return change;
 }
 
 module.exports = toggleHeaders;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
     "read-metadata": "^1.0.0",
-    "slate": "^0.21.2",
+    "slate": "^0.22.0",
     "watchify": "^3.7.0"
   },
   "scripts": {


### PR DESCRIPTION
Hello! I've tried to update your plugin to work with the latest release of slate (0.22.x) which had some big breaking changes (like the deprecation of `state.transform` in favor of `change`).

I've got almost everything to work without changing too much except for the TAB key which throws an error if you try to tab to a cell with an empty text (`''`) content, but works if there is at least one space (`' '`).

Maybe you could find where the problem is and roll back `createCell` to use and empty text.

Let me know if something is missing!